### PR TITLE
Updated README.md following split of bhmm toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,34 @@
 [![Build Status](https://travis-ci.org/bhmm/bhmm.png?branch=master)](https://travis-ci.org/bhmm/bhmm)
 
-# Bayesian hidden Markov models for analysis of single-molecule trajectory data
+# Bayesian hidden Markov model toolkit
 
-This project provides tools for estimating the number of metastable states, rate constants between the states, equilibrium populations, distributions characterizing the states, and distributions of these quantities from single-molecule data. This data could be FRET data, single-molecule pulling data, or any data where one or more observables are recorded as a function of time. A Hidden Markov Model (HMM) is used to interpret the observed dynamics, and a distribution of models that fit the data is sampled using Bayesian inference techniques and Markov chain Monte Carlo (MCMC), allowing for both the characterization of uncertainties in the model and modeling of the expected information gain by new experiments.
+This toolkit provides machinery for sampling from the Bayesian posterior of hidden Markov models with various choices of prior and output models.
 
-## Manifest
-* `LICENSE` - full text of LGPL v3 license
-* `matlab/` - Matlab code for BHMM
-* `docs/` - documentation
-* `manscripts/` - manuscript sources
-* `references/` - collected references from manuscript
+## Installation
 
-## Authors
-* John D. Chodera <john.chodera@choderalab.org>
-* Bettina Keller <bettina.keller@fu-berlin.de>
-* Phillip J. Elms <elms@berkeley.edu>
-* Frank Noé <frank.noe@fu-berlin.de>
-* Christian M. Kaiser <kaiser.jhu.bio@gmail.com>
-* Aaron Ewall-Wice
-* Susan Marqusee
-* Carlos Bustamante
-* Nina Singhal Hinrichs <nshinrichs@uchicago.edu>
+### Installation from conda
+
+The easiest way to install `bhmm` is via the [`conda` package manager](http://conda.pydata.org/):
+```
+conda config --add channels http://conda.binstar.org/omnia
+conda install bhmm
+```
+
+### Installation from source
+
+```
+python setup.py install
+```
+
+## References
+
+See [here](http://arxiv.org/abs/1108.1430) for a manuscript describing the theory behind using Gibbs sampling to sample from Bayesian hidden Markov model posteriors.
+
+> Bayesian hidden Markov model analysis of single-molecule force spectroscopy: Characterizing kinetics under measurement uncertainty.
+> John D. Chodera, Phillip Elms, Frank Noé, Bettina Keller, Christian M. Kaiser, Aaron Ewall-Wice, Susan Marqusee, Carlos Bustamante, Nina Singhal Hinrichs
+> http://arxiv.org/abs/1108.1430
+
+## Package maintainers
+* Frank Noé <frank.noe@fu-berlin.de>, Freie Universität Berlin
+* Martin K. Scherer <m.scherer@fu-berlin.de>, Freie Universität Berlin
+* John D. Chodera <john.chodera@choderalab.org>, Sloan Kettering Institute


### PR DESCRIPTION
This updates the `README.md` to reflect that this package just has the BHMM toolkit.
