### PR TITLE
Init splitstates

### DIFF
--- a/bhmm/estimators/_tmatrix_disconnected.py
+++ b/bhmm/estimators/_tmatrix_disconnected.py
@@ -39,6 +39,15 @@ def closed_sets(C, mincount_connectivity=0):
     return closed
 
 
+def nonempty_set(C, mincount_connectivity=0):
+    """ Returns the set of states that have at least one incoming or outgoing count """
+    # truncate to states with at least one observed incoming or outgoing count.
+    if mincount_connectivity > 0:
+        C = C.copy()
+        C[np.where(C < mincount_connectivity)] = 0
+    return np.where(C.sum(axis=0) + C.sum(axis=1) > 0)[0]
+
+
 def estimate_P(C, reversible=True, fixed_statdist=None, maxiter=1000000, maxerr=1e-8, mincount_connectivity=0):
     """ Estimates full transition matrix for general connectivity structure
 

--- a/bhmm/estimators/maximum_likelihood.py
+++ b/bhmm/estimators/maximum_likelihood.py
@@ -101,28 +101,17 @@ class MaximumLikelihoodEstimator(object):
         self._Ts = [len(o) for o in observations]
         self._maxT = np.max(self._Ts)
 
-        # Store the number of states.
+        # Set parameters
         self._nstates = nstates
+        self._reversible = reversible
+        self._stationary = stationary
 
         if initial_model is not None:
             # Use user-specified initial model, if provided.
             self._hmm = copy.deepcopy(initial_model)
-            # consistency checks
-            if self._hmm.is_stationary != stationary:
-                logger().warn('Requested stationary=' + str(stationary) + ' but initial model is stationary=' +
-                              str(self._hmm.is_stationary) + '. Using stationary='+str(self._hmm.is_stationary))
-            if self._hmm.is_reversible != reversible:
-                logger().warn('Requested reversible=' + str(reversible) + ' but initial model is reversible=' +
-                              str(self._hmm.is_reversible) + '. Using reversible='+str(self._hmm.is_reversible))
-            # setting parameters
-            self._reversible = self._hmm.is_reversible
-            self._stationary = self._hmm.is_stationary
         else:
             # Generate our own initial model.
             self._hmm = bhmm.init_hmm(observations, nstates, type=type)
-            # setting parameters
-            self._reversible = reversible
-            self._stationary = stationary
 
         # stationary and initial distribution
         self._fixed_stationary_distribution = None
@@ -409,7 +398,7 @@ class MaximumLikelihoodEstimator(object):
                 converged = False  # unset converged
                 connected_sets = connected_sets_new
 
-            #  print 't_fb: ', str(1000.0*(t2-t1)), 't_up: ', str(1000.0*(t3-t2)), 'L = ', loglik, 'dL = ', (loglik - self._likelihoods[it-1])
+            print 't_fb: ', str(1000.0*(t2-t1)), 't_up: ', str(1000.0*(t3-t2)), 'L = ', loglik, 'dL = ', (loglik - self._likelihoods[it-1])
 
             logger().info(str(it) + " ll = " + str(loglik))
             # print self.model.output_model

--- a/bhmm/hmm/discrete_hmm.py
+++ b/bhmm/hmm/discrete_hmm.py
@@ -19,8 +19,7 @@ class DiscreteHMM(HMM, DiscreteOutputModel):
             raise TypeError('Given hmm is not a discrete HMM, but has an output model of type: '+
                             str(type(hmm.output_model)))
         DiscreteOutputModel.__init__(self, hmm.output_model.output_probabilities)
-        HMM.__init__(self, hmm.transition_matrix, self, lag=hmm.lag, Pi=hmm.initial_distribution,
-                     stationary=hmm.is_stationary, reversible=hmm.is_reversible)
+        HMM.__init__(self, hmm.initial_distribution, hmm.transition_matrix, self, lag=hmm.lag)
 
 
 class SampledDiscreteHMM(DiscreteHMM, SampledHMM):

--- a/bhmm/hmm/gaussian_hmm.py
+++ b/bhmm/hmm/gaussian_hmm.py
@@ -29,8 +29,7 @@ class GaussianHMM(HMM, GaussianOutputModel):
             raise TypeError('Given hmm is not a Gaussian HMM, but has an output model of type: '+
                             str(type(hmm.output_model)))
         GaussianOutputModel.__init__(self, hmm.nstates, means=hmm.output_model.means, sigmas=hmm.output_model.sigmas)
-        HMM.__init__(self, hmm.transition_matrix, self, lag=hmm.lag, Pi=hmm.initial_distribution,
-                     stationary=hmm.is_stationary, reversible=hmm.is_reversible)
+        HMM.__init__(self, hmm.initial_distribution, hmm.transition_matrix, self, lag=hmm.lag)
 
 
 class SampledGaussianHMM(GaussianHMM, SampledHMM):

--- a/bhmm/init/discrete.py
+++ b/bhmm/init/discrete.py
@@ -49,8 +49,7 @@ def coarse_grain_transition_matrix(P, M, eps=0):
     return P_coarse
 
 
-# TODO: does not implement fixed stationary distribution (on macrostates) yet.
-def msm_to_hmm(C, Prev, nstates, P=None, indexes=None, nfull=None, eps_A=None, eps_B=None):
+def estimate_initial_coarse_graining(C, Prev, nstates, eps=None):
     """ Initial HMM based from MSM
 
     Parameters
@@ -61,76 +60,54 @@ def msm_to_hmm(C, Prev, nstates, P=None, indexes=None, nfull=None, eps_A=None, e
         Reversible transition matrix. Used to computed metastable sets with PCCA.
     nstates : int
         Number of coarse states.
-    P : ndarray(n, n)
-        Transition matrix to be coarse-grained for the initial HMM. If P=None,
-        will use P=Prev.
-    indexes : ndarray(n) or None
-        Mapping from rows of Prev and P to state indexes of the full state space.
-        This should be used, if Prev and P only live on a subset of states.
-        None means, that the indexes of Prev/P rows are identical to the full
-        state space.
-    nfull : int or None
-        Number of states in full state space. If None, nfull = Pref.shape[0].
-    eps_A : float or None
-        Minimum transition probability. Default: 0.01 / nstates
-    eps_B : float or None
-        Minimum output probability. Default: 0.01 / nfull
+    eps : float or None
+        Minimum output probability. Default: 0.01 / n
+
+    Returns
+    -------
+    M : ndarray(n, m)
+        membership matrix
+    B : ndarray(m, n)
+        output probabilities
 
     """
-    from bhmm.estimators._tmatrix_disconnected import stationary_distribution
-
     # input
-    if P is None:
-        P = Prev
     n = Prev.shape[0]
-    if nfull is None:
-        nfull = n
-    else:
-        assert indexes is not None, 'If nfull is specified, must specify indexes too.'
-    if indexes is None:
-        indexes = np.arange(nfull)
-    if eps_A is None:  # default transition probability, in order to avoid zero columns
-        eps_A = 0.01 / nstates
-    if eps_B is None:  # default output probability, in order to avoid zero columns
-        eps_B = 0.01 / nfull
+    if eps is None:  # default output probability, in order to avoid zero columns
+        eps = 0.01 / n
 
-    # coarse-grain
+    # check if we have enough MSM states to support the requested number of metastable states
     if nstates > n:
-        raise NotImplementedError('Trying to initialize '+str(nstates)+'-state HMM from smaller '+str(n)+'-state MSM.')
-    else:
-        # pcca
-        from msmtools.analysis.dense.pcca import PCCA
-        pcca_obj = PCCA(Prev, nstates)
-        M = pcca_obj.memberships
+        raise NotImplementedError('Trying to initialize ' + str(nstates) + '-state HMM from smaller '
+                                  + str(n) + '-state MSM.')
 
-        # coarse-grained transition matrix
-        A = coarse_grain_transition_matrix(P, M, eps=eps_A)
+    # pcca
+    from msmtools.analysis.dense.pcca import PCCA
+    pcca_obj = PCCA(Prev, nstates)
 
-        # compress stationary probabilities.
-        C_coarse = M.T.dot(C).dot(M)
-        pi = stationary_distribution(C_coarse, A)  # need C_coarse in case if A is disconnected
+    # memberships and output probabilities
+    M = pcca_obj.memberships
 
-        # full state space output matrix
-        B = eps_B * np.ones((nstates, nfull), dtype=np.float64)
-        # fill PCCA distributions if they exceed eps_B
-        B[:, indexes] = np.maximum(B[:, indexes], pcca_obj.output_probabilities)
-        # renormalize B to make it row-stochastic
-        B /= B.sum(axis=1)[:, None]
+    # full state space output matrix
+    B = eps * np.ones((nstates, n), dtype=np.float64)
+    # fill PCCA distributions if they exceed eps_B
+    B = np.maximum(B, pcca_obj.output_probabilities)
+    # renormalize B to make it row-stochastic
+    B /= B.sum(axis=1)[:, None]
 
-    return pi, A, B
+    return M, B
 
 
-def estimate_initial_hmm(observations, nstates, reversible=True, eps_A=None, eps_B=None):
+def estimate_initial_hmm(C, nstates, reversible=True, P=None, active=None,
+                         eps_A=None, eps_B=None, separate=None):
     """Generate an initial HMM with discrete output densities
 
-    Initialized HMM as described in [1]_. First estimates a Markov state model
+    Initializes HMM as described in [1]_. First estimates a Markov state model
     on the given observations, then uses PCCA+ to coarse-grain the transition
     matrix [2]_ which initializes the HMM transition matrix. The HMM output
     probabilities are given by Bayesian inversion from the PCCA+ memberships [1]_.
 
-    A weak prior count matrix may be added in the first MSM estimation step, if
-    the number of nontransient (closed) sets is smaller than the requested number
-    of hidden states. The regularization parameters eps_A and eps_B are used
+    The regularization parameters eps_A and eps_B are used
     to guarantee that the hidden transition matrix and output probability matrix
     have no zeros. HMM estimation algorithms such as the EM algorithm and the
     Bayesian sampling algorithm cannot recover from zero entries, i.e. once they
@@ -138,16 +115,24 @@ def estimate_initial_hmm(observations, nstates, reversible=True, eps_A=None, eps
 
     Parameters
     ----------
-    observations : list of ndarray((T_i), dtype=int)
-        list of arrays of length T_i with observation data
+    C : ndarray(n, n)
+        Transition count matrix
     nstates : int
-        The number of states.
+        The number of hidden states.
     reversible : bool
         Estimate reversible HMM transition matrix.
+    P : ndarray(n, n)
+        Transition matrix estimated from C (with option reversible). Use this
+        option if P has already been estimated to avoid estimating it twice.
+    active : ndarray(N, dtype=bool)
+        Boolean array marking which states of the full state space are used by C and P
     eps_A : float or None
         Minimum transition probability. Default: 0.01 / nstates
     eps_B : float or None
         Minimum output probability. Default: 0.01 / nfull
+    separate : None or iterable of int
+        Force the given set of observed states to stay in a separate hidden state.
+        The remaining nstates-1 states will be assigned by a metastable decomposition.
 
     Raises
     ------
@@ -158,9 +143,9 @@ def estimate_initial_hmm(observations, nstates, reversible=True, eps_A=None, eps
     --------
     Generate initial model for a discrete output model.
 
-    >>> from bhmm import testsystems
-    >>> [model, observations, states] = testsystems.generate_synthetic_observations(output_model_type='discrete')
-    >>> initial_model = estimate_initial_hmm(observations, model.nstates)
+    >>> import numpy as np
+    >>> C = np.array([[0.5, 0.5, 0.0], [0.4, 0.5, 0.1], [0.0, 0.1, 0.9]])
+    >>> initial_model = estimate_initial_hmm(C, 2)
 
     References
     ----------
@@ -174,50 +159,91 @@ def estimate_initial_hmm(observations, nstates, reversible=True, eps_A=None, eps
     """
     # local imports
     from bhmm.estimators import _tmatrix_disconnected
+    import sys
 
     # MICROSTATE COUNT MATRIX
-    C_full = msmtools.estimation.count_matrix(observations, 1).toarray()  # need to be dense here
+    C_full = C
+    nfull = C_full.shape[0]
+
+    # INPUTS
+    if eps_A is None:  # default transition probability, in order to avoid zero columns
+        eps_A = 0.01 / nstates
+    if eps_B is None:  # default output probability, in order to avoid zero columns
+        eps_B = 0.01 / nfull
+
     # truncate to states with at least one observed incoming or outgoing count.
-    indexes = np.where(C_full.sum(axis=0) + C_full.sum(axis=1) > 0)[0]
-    C = C_full[np.ix_(indexes, indexes)]
+    nonempty = _tmatrix_disconnected.nonempty_set(C_full)
+    C_nonempty = C_full[np.ix_(nonempty, nonempty)]
+
+    # when using separate states, only keep the nonempty ones (the others don't matter)
+    if separate is None:
+        nonseparate = nonempty.copy()
+        nmeta = nstates
+    else:
+        separate = np.array(list(set(separate).intersection(set(nonempty))))
+        nonseparate = np.array(list(set(nonempty) - set(separate)))
+        nmeta = nstates - 1
+
     # check if we can proceed
-    if indexes.size < nstates:
-        raise NotImplementedError('Trying to initialize ' + str(nstates) + '-state HMM from smaller '
-                                  + str(indexes.size) + '-state MSM.')
+    if nonseparate.size < nmeta:
+        raise NotImplementedError('Trying to initialize ' + str(nmeta) + '-state HMM from smaller '
+                                  + str(nonseparate.size) + '-state MSM.')
 
     # MICROSTATE TRANSITION MATRIX (MSM). This matrix may be disconnected and have transient states
-    P_msm = _tmatrix_disconnected.estimate_P(C, reversible=reversible)
+    if P is not None:
+        P_msm = P[nonempty, :][:, nonempty]  # if we already have P, just remove empty states
+    else:
+        P_msm = _tmatrix_disconnected.estimate_P(C_nonempty, reversible=reversible)
+    pi_msm = _tmatrix_disconnected.stationary_distribution(C_nonempty, P_msm)
+    pi_full = np.zeros(nfull)
+    pi_full[nonempty] = pi_msm
 
-    # MICROSTATE TRANSITION MATRIX FOR PCCA+
-    # does the count matrix too few closed sets to give nstates metastable states? Then we need a prior
-    if len(_tmatrix_disconnected.closed_sets(C)) < nstates:
-        msm_prior = 0.001
-        B = msm_prior * np.eye(C.shape[0])  # diagonal prior
-        B += msmtools.estimation.prior_neighbor(C, alpha=msm_prior)  # neighbor prior
-        C_post = C + B  # posterior
-        P_for_pcca = _tmatrix_disconnected.estimate_P(C_post, reversible=True)
-    elif reversible:  # in this case we already have a reversible estimate that is large enough
+    # NONSEPARATE TRANSITION MATRIX FOR PCCA+
+    C_nonseparate = C_full[np.ix_(nonseparate, nonseparate)]
+    if reversible and nonseparate.size == nonempty.size:  # in this case we already have a reversible estimate that is large enough
         P_for_pcca = P_msm
-    else:  # enough metastable states, but not yet reversible. re-estimate
-        P_for_pcca = _tmatrix_disconnected.estimate_P(C, reversible=True)
+    else:  # not yet reversible. re-estimate
+        P_for_pcca = _tmatrix_disconnected.estimate_P(C_nonseparate, reversible=True)
 
-    # INITIALIZE HMM
-    pi, A, B = msm_to_hmm(C, P_for_pcca, nstates, P=P_msm, indexes=indexes, nfull=C_full.shape[0],
-                          eps_A=eps_A, eps_B=eps_B)
+    # COARSE-GRAINING
+    if nonseparate.size > nmeta:
+        M_ns, B_ns = estimate_initial_coarse_graining(C_nonseparate, P_for_pcca, nmeta, eps=eps_B)
+    else:  # equal size
+        M_ns = np.eye(nmeta)
+        B_ns = np.eye(nmeta)
+
+    # MEMBERSHIP
+    M = np.zeros((nfull, nstates))
+    M[nonseparate, :nmeta] = M_ns
+    if separate is not None:  # add separate states
+        M[separate, -1] = 1
+
+    # COARSE-GRAINED TRANSITION MATRIX
+    P_coarse = coarse_grain_transition_matrix(P_msm, M[nonempty], eps=eps_A)
     if reversible:
-        A = _tmatrix_disconnected.enforce_reversible_on_closed(A)
+        P_coarse = _tmatrix_disconnected.enforce_reversible_on_closed(P_coarse)
+    C_coarse = M[nonempty].T.dot(C_nonempty).dot(M[nonempty])
+    pi_coarse = _tmatrix_disconnected.stationary_distribution(C_coarse, P_coarse)  # need C_coarse in case if A is disconnected
 
-    #print 'cg pi: ', pi
-    #print 'cg A:\n ', A
-    #print 'cg B:\n ', B
+    # COARSE-GRAINED OUTPUT DISTRIBUTION
+    B = np.zeros((nstates, nfull))
+    B[:nmeta, nonseparate] = B_ns
+    if separate is not None:  # add separate states
+        B[-1, separate] = pi_full[separate]
+    B /= B.sum(axis=1)[:, None]  # normalize rows
+
+    # print 'cg pi: ', pi_coarse
+    # print 'cg A:\n ', P_coarse
+    # print 'cg B:\n ', B
 
     logger().info('Initial model: ')
-    logger().info('transition matrix = \n'+str(A))
+    logger().info('initial distribution = \n'+str(pi_coarse))
+    logger().info('transition matrix = \n'+str(P_coarse))
     logger().info('output matrix = \n'+str(B.T))
 
     # initialize HMM
     output_model = DiscreteOutputModel(B)
-    model = HMM(pi, A, output_model)
+    model = HMM(pi_coarse, P_coarse, output_model)
     return model
 
 

--- a/bhmm/output_models/gaussian.py
+++ b/bhmm/output_models/gaussian.py
@@ -314,7 +314,7 @@ class GaussianOutputModel(OutputModel):
             raise RuntimeError('Implementation '+str(self.__impl__)+' not available')
 
 
-    def _estimate_output_model(self, observations, weights):
+    def estimate(self, observations, weights):
         """
         Fits the output model given the observations and weights
 
@@ -339,7 +339,7 @@ class GaussianOutputModel(OutputModel):
 
         Update the observation model parameters my a maximum-likelihood fit.
 
-        >>> output_model._estimate_output_model(observations, weights)
+        >>> output_model.estimate(observations, weights)
 
         """
         # sizes
@@ -373,7 +373,7 @@ class GaussianOutputModel(OutputModel):
         self._sigmas = np.sqrt(self.sigmas)
 
 
-    def _sample_output_model(self, observations):
+    def sample(self, observations, prior=None):
         """
         Sample a new set of distribution parameters given a sample of observations from the given state.
 
@@ -383,6 +383,8 @@ class GaussianOutputModel(OutputModel):
         ----------
         observations :  [ numpy.array with shape (N_k,) ] with `nstates` elements
             observations[k] is a set of observations sampled from state `k`
+        prior : object
+            prior option for compatibility
 
         Examples
         --------
@@ -397,7 +399,7 @@ class GaussianOutputModel(OutputModel):
 
         Update output parameters by sampling.
 
-        >>> output_model._sample_output_model(observations)
+        >>> output_model.sample(observations)
 
         """
         for state_index in range(self.nstates):


### PR DESCRIPTION
- Improved initialization and made them more robust
- Enabling Dirichlet priors for bhmm sampling (transition matrix and initial distribution) and discrete output models.
