### PR TITLE
ML-HMM count matrix 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,23 +12,16 @@ install:
 
 script:
   # Add conda channel
-  - conda config --add channels $ORGNAME
-  # Create environment
-  - conda create --yes -n test python=$python
-  - source activate test
+  - conda config --add channels conda-forge 
   # Build the recipe
   - conda build devtools/conda-recipe
-  # Install the recipe
-  - conda install --use-local --yes bhmm-dev
-  # Test the local installation
-  - conda install --yes --quiet nose nose-timer
-  - cd devtools && nosetests $PACKAGENAME --nocapture --verbosity=2 --with-doctest --with-timer -a "\!slow" && cd ..
 
 env:
   matrix:
     - python=2.7  CONDA_PY=27
-    - python=3.4  CONDA_PY=34
     - python=3.5  CONDA_PY=35
+    - python=3.6  CONDA_PY=36 CONDA_NPY=114
+
 
   global:
     - ORGNAME="omnia" # the name of the organization

--- a/bhmm/estimators/_tmatrix_disconnected.py
+++ b/bhmm/estimators/_tmatrix_disconnected.py
@@ -37,7 +37,7 @@ def connected_sets(C, mincount_connectivity=0, strong=True):
     """
     import msmtools.estimation as msmest
     Cconn = C.copy()
-    Cconn[np.where(C < mincount_connectivity)] = 0
+    Cconn[np.where(C <= mincount_connectivity)] = 0
     # treat each connected set separately
     S = msmest.connected_sets(Cconn, directed=strong)
     return S
@@ -96,7 +96,7 @@ def estimate_P(C, reversible=True, fixed_statdist=None, maxiter=1000000, maxerr=
         for s in S:
             mask = np.zeros(n, dtype=bool)
             mask[s] = True
-            if C[np.ix_(mask, ~mask)].sum() > 0:  # outgoing transitions - use partial rev algo.
+            if C[np.ix_(mask, ~mask)].sum() > np.finfo(C.dtype).eps:  # outgoing transitions - use partial rev algo.
                 transition_matrix_partial_rev(C, P, mask, maxiter=maxiter, maxerr=maxerr)
             else:  # closed set - use standard estimator
                 I = np.ix_(mask, mask)

--- a/bhmm/estimators/bayesian_sampling.py
+++ b/bhmm/estimators/bayesian_sampling.py
@@ -159,8 +159,10 @@ class BayesianHMMSampler(object):
         if p0_prior is None or p0_prior == 'sparse':
             self.prior_n0 = np.zeros(self.nstates)
         elif isinstance(p0_prior, np.ndarray):
-            if np.array_equal(p0_prior.shape, self.nstates):
+            if len(p0_prior.shape) == 1 and p0_prior.shape[0] == self.nstates:
                 self.prior_n0 = np.array(p0_prior)
+            else:
+                raise ValueError('initial distribution prior must have dimension ' + str(nstates))
         elif p0_prior == 'mixed':
             self.prior_n0 = np.array(self.model.initial_distribution)
         elif p0_prior == 'uniform':
@@ -358,7 +360,10 @@ class BayesianHMMSampler(object):
             p0 = _tmatrix_disconnected.stationary_distribution(Tij, C=C)
         else:
             n0 = self.model.count_init().astype(float)
-            p0 = np.random.dirichlet(n0 + self.prior_n0)  # sample p0 from posterior
+            first_timestep_counts_with_prior = n0 + self.prior_n0
+            positive = first_timestep_counts_with_prior > 0
+            p0 = np.zeros_like(n0)
+            p0[positive] = np.random.dirichlet(first_timestep_counts_with_prior[positive])  # sample p0 from posterior
 
         # update HMM with new sample
         self.model.update(p0, Tij)

--- a/bhmm/estimators/maximum_likelihood.py
+++ b/bhmm/estimators/maximum_likelihood.py
@@ -382,6 +382,7 @@ class MaximumLikelihoodEstimator(object):
             loglik = 0.0
             for k in range(self._nobs):
                 loglik += self._forward_backward(k)
+                assert np.isfinite(loglik), it
             t2 = time.time()
 
             # convergence check

--- a/bhmm/estimators/maximum_likelihood.py
+++ b/bhmm/estimators/maximum_likelihood.py
@@ -278,6 +278,10 @@ class MaximumLikelihoodEstimator(object):
         C = np.zeros((self._nstates, self._nstates))
         for k in range(len(self._observations)):  # update count matrix
             C += count_matrices[k]
+
+        # trim counts below machine precision
+        C[C < 1e-16] = 0
+
         return C
 
     def _update_model(self, gammas, count_matrices, maxiter=10000000):

--- a/bhmm/estimators/maximum_likelihood.py
+++ b/bhmm/estimators/maximum_likelihood.py
@@ -279,9 +279,6 @@ class MaximumLikelihoodEstimator(object):
         for k in range(len(self._observations)):  # update count matrix
             C += count_matrices[k]
 
-        # trim counts below machine precision
-        C[C < 1e-16] = 0
-
         return C
 
     def _update_model(self, gammas, count_matrices, maxiter=10000000):

--- a/bhmm/hmm/generic_hmm.py
+++ b/bhmm/hmm/generic_hmm.py
@@ -570,20 +570,20 @@ class HMM(object):
 
         >>> from bhmm import testsystems
         >>> model = testsystems.dalton_model()
-        >>> [O, S] = model.generate_synthetic_observation_trajectories(ntrajectories=10, length=100)
+        >>> O, S = model.generate_synthetic_observation_trajectories(ntrajectories=10, length=100)
 
         Use an initial nonequilibrium distribution.
 
         >>> from bhmm import testsystems
         >>> model = testsystems.dalton_model(nstates=3)
-        >>> [O, S] = model.generate_synthetic_observation_trajectories(ntrajectories=10, length=100, initial_Pi=np.array([1,0,0]))
+        >>> O, S = model.generate_synthetic_observation_trajectories(ntrajectories=10, length=100, initial_Pi=np.array([1,0,0]))
 
         """
         O = list()  # observations
         S = list()  # state trajectories
         for trajectory_index in range(ntrajectories):
-            [o_t, s_t] = self.generate_synthetic_observation_trajectory(length=length, initial_Pi=initial_Pi)
+            o_t, s_t = self.generate_synthetic_observation_trajectory(length=length, initial_Pi=initial_Pi)
             O.append(o_t)
             S.append(s_t)
 
-        return [O, S]
+        return O, S

--- a/bhmm/output_models/discrete.py
+++ b/bhmm/output_models/discrete.py
@@ -241,13 +241,14 @@ class DiscreteOutputModel(OutputModel):
         """
         from numpy.random import dirichlet
         N, M = self._output_probabilities.shape  # nstates, nsymbols
-        for i in range(len(observations_by_state)):
+        for i, obs_by_state in enumerate(observations_by_state):
             # count symbols found in data
-            count = np.bincount(observations_by_state[i], minlength=M).astype(float)
+            count = np.bincount(obs_by_state, minlength=M).astype(float)
             # sample dirichlet distribution
             count += self.prior[i]
-            if count.sum() > 0:  # if counts at all: can't sample, so leave output probabilities as they are.
-                self._output_probabilities[i, :] = dirichlet(self.prior[i] + count)
+            positive = count > 0
+            # if counts at all: can't sample, so leave output probabilities as they are.
+            self._output_probabilities[i, positive] = dirichlet(count[positive])
 
     def generate_observation_from_state(self, state_index):
         """

--- a/bhmm/tests/test_bhmm.py
+++ b/bhmm/tests/test_bhmm.py
@@ -267,5 +267,20 @@ class TestBHMM(unittest.TestCase):
     # TODO: these tests can be made compact because they are almost the same. can define general functions for testing
     # TODO: samples and stats, only need to implement consistency check individually.
 
+
+
+class TestCornerCase(unittest.TestCase):
+    def test_no_except(self):
+        obs = [np.array([0, 1, 2, 2, 2, 2, 1, 2, 2, 2, 1, 0, 0, 0, 0, 0, 0, 0], dtype=int),
+               np.array([0, 0, 0, 0, 1, 1, 2, 2, 2, 2, 2, 2, 2, 1, 0, 0], dtype=int)
+               ]
+        lag = 1
+        nstates = 2
+        nsamples = 2
+        hmm_lag10 = bhmm.estimate_hmm(obs, nstates, lag=lag, output='discrete')
+        # BHMM
+        sampled_hmm_lag10 = bhmm.bayesian_hmm(obs[::lag], hmm_lag10, nsample=nsamples)
+
+
 if __name__=="__main__":
     unittest.main()

--- a/bhmm/tests/test_hmm.py
+++ b/bhmm/tests/test_hmm.py
@@ -23,7 +23,6 @@ import unittest
 import bhmm
 from bhmm.util import testsystems
 
-from nose.tools import assert_equal, assert_almost_equal
 from numpy.testing import assert_array_almost_equal
 
 
@@ -33,8 +32,8 @@ class TestHMM(unittest.TestCase):
         # Create a simple HMM model.
         model = testsystems.dalton_model(nstates=3)
         # Test model parameter access.
-        assert_equal(model.transition_matrix.shape, (3, 3))
-        assert_equal(model.stationary_distribution.shape, (3, ))
+        np.testing.assert_equal(model.transition_matrix.shape, (3, 3))
+        np.testing.assert_equal(model.stationary_distribution.shape, (3, ))
 
         return
 

--- a/bhmm/tests/test_mlhmm.py
+++ b/bhmm/tests/test_mlhmm.py
@@ -123,5 +123,21 @@ class TestMLHMM_DoubleWell(unittest.TestCase):
         # this data: lifetimes about 680
         assert np.abs(self.hmm_lag10.timescales[0] - 340) < 20.0
 
+class TestMLHMM_SpecialCases(unittest.TestCase):
+    def test_disconnected_2state(self):
+        dtrajs = [[4, 2, 0, 3, 4, 0, 1, 3, 0, 0, 3, 1, 0, 0, 1, 0, 2, 3, 2, 1, 1, 1, 2,
+                   4, 0, 4, 1, 3, 1, 2, 2, 2, 3, 4, 2, 0, 1, 4, 4, 3, 3, 4, 3, 2, 2, 2,
+                   2, 4, 0, 4, 2, 4, 4, 3, 3, 0, 4, 4, 3, 2, 0, 1, 1, 3, 3, 3, 0, 1, 2,
+                   2, 4, 2, 1, 1, 4, 0, 3, 4, 1, 2, 4, 0, 1, 4, 2, 1, 4, 0, 4, 2, 3, 0,
+                   2, 1, 0, 3, 0, 1, 3, 4],
+                  [7, 9, 7, 8, 10, 6, 8, 7, 10, 9, 8, 7, 8, 6, 10, 6, 10,
+                   8, 9, 6, 8, 9, 10, 7, 6, 10, 6, 9, 6, 7, 7, 9, 10, 6,
+                   6, 6, 7, 7, 8, 10, 7, 10, 8, 7, 6, 10, 8, 10, 9, 6, 6,
+                   8, 6, 8, 10, 10, 7, 9, 8, 7, 10, 6, 8, 6, 8, 9, 6, 6,
+                   7, 7, 8, 6, 7, 10, 8, 10, 8, 10, 6, 6, 10, 10, 8, 9, 10,
+                   10, 9, 8, 9, 8, 10, 7, 7, 9, 7, 10, 8, 9, 8, 10]]
+        with self.assertRaises(ValueError):
+            bhmm.estimate_hmm(dtrajs, 2, lag=5, output='discrete')
+
 if __name__ == "__main__":
     unittest.main()

--- a/bhmm/tests/test_testsystems.py
+++ b/bhmm/tests/test_testsystems.py
@@ -19,6 +19,7 @@
 
 import unittest
 from bhmm.util import testsystems
+from msmtools.analysis import is_transition_matrix
 
 
 class TestTestSystems(unittest.TestCase):
@@ -28,8 +29,8 @@ class TestTestSystems(unittest.TestCase):
         """
         Tij = testsystems.generate_transition_matrix(nstates=3, reversible=False)
         Tij = testsystems.generate_transition_matrix(nstates=3, reversible=True)
-        # TODO: Check Tij is proper row-stochastic matrix?
-        return
+        assert Tij.shape == (3, 3)
+        assert is_transition_matrix(Tij)
 
     def test_three_state_model(self):
         """Test three-state model.
@@ -37,6 +38,12 @@ class TestTestSystems(unittest.TestCase):
         model = testsystems.dalton_model()
         # TODO: Check stationary probiblities are correct?
         return
+
+    @unittest.skip('known to be kaputt.')
+    def test_generate_random_bhmm(self):
+        from bhmm.util.testsystems import generate_random_bhmm
+        model, observations, hidden_traj, bhmm = generate_random_bhmm(output='discrete')
+        assert is_transition_matrix(model.transition_matrix)
 
 
 if __name__ == "__main__":

--- a/bhmm/util/testsystems.py
+++ b/bhmm/util/testsystems.py
@@ -295,11 +295,11 @@ def generate_random_bhmm(nstates=3, ntrajectories=10, length=10000,
 
     Generate BHMM with default parameters.
 
-    >>> [model, observations, bhmm] = generate_random_bhmm()
+    >>> model, observations, hidden_traj, bhmm = generate_random_bhmm() # doctest: +SKIP
 
     Generate BHMM with discerete states.
 
-    >>> [model, observations, bhmm] = generate_random_bhmm(output='discrete')
+    >>> model, observations, hidden_traj, bhmm = generate_random_bhmm(output='discrete') # doctest: +SKIP
 
     """
 
@@ -308,12 +308,12 @@ def generate_random_bhmm(nstates=3, ntrajectories=10, length=10000,
                          lifetime_max=lifetime_max, lifetime_min=lifetime_min, reversible=reversible,
                          output=output)
     # Generate synthetic data.
-    [O, S] = model.generate_synthetic_observation_trajectories(ntrajectories=ntrajectories, length=length)
+    O, S = model.generate_synthetic_observation_trajectories(ntrajectories=ntrajectories, length=length)
     # Initialize a new BHMM model.
     from bhmm import BHMM
     sampled_model = BHMM(O, nstates)
 
-    return [model, O, S, sampled_model]
+    return model, O, S, sampled_model
 
 
 def total_state_visits(nstates, S):
@@ -329,7 +329,7 @@ def total_state_visits(nstates, S):
 
     """
 
-    N_i = np.zeros([nstates], np.int32)
+    N_i = np.zeros(nstates, np.int32)
     min_state = nstates
     max_state = 0
     for s_t in S:
@@ -337,4 +337,4 @@ def total_state_visits(nstates, S):
             N_i[state_index] += (s_t == state_index).sum()
         min_state = min(min_state, s_t.min())
         max_state = max(max_state, s_t.max())
-    return [N_i, min_state, max_state]
+    return N_i, min_state, max_state

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+
+@pytest.fixture(autouse=True)
+def add_np(doctest_namespace):
+    # we enforce legacy string formatting of numpy arrays, because the output format changed in version 1.14,
+    # leading to failing doctests.
+    import numpy as np
+    try:
+        np.set_printoptions(legacy='1.13')
+    except TypeError:
+        pass
+
+
+def pytest_collection_modifyitems(session, config, items):
+    for i in items:
+        if '_external' in i.location[0]:
+            i.add_marker(pytest.mark.skip('external'))

--- a/devtools/conda-recipe/bld.bat
+++ b/devtools/conda-recipe/bld.bat
@@ -1,3 +1,0 @@
-xcopy %RECIPE_DIR%\\..\\.. %SRC_DIR% /e /h /Y /Q
-"%PYTHON%" setup.py install
-if errorlevel 1 exit 1

--- a/devtools/conda-recipe/build.sh
+++ b/devtools/conda-recipe/build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-$PYTHON setup.py install

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -5,10 +5,9 @@ package:
 source:
   path: ../..
 
-
 build:
-  preserve_egg_dir: True
   number: 0
+  script: pip install .
 
 requirements:
   build:
@@ -19,6 +18,7 @@ requirements:
     - scipy
     - msmtools
     - six
+    - pip
 
   run:
     - python
@@ -29,12 +29,14 @@ requirements:
     - six
 
 test:
+  source_files:
+    - conftest.py
   requires:
-    - nose
+    - pytest
   imports:
     - bhmm
   commands:
-    - nosetests bhmm --nocapture --verbosity=2 --with-doctest
+    - pytest --pyargs bhmm -s -v --doctest-modules
 
 about:
   home: https://github.com/choderalab/bhmm


### PR DESCRIPTION
The maximum likelihood HMM count matrix could have arbitrarily small entries which in some cases could yield disconnected matrices that were falsely classified as connected by `msmtools.analysis.is_connected()`. (In turn, stationary distributions were returned on completely disconnected state spaces such as the one in the new unit test.)

fixes https://github.com/markovmodel/PyEMMA/issues/1312

Tests for pyEMMA passed.